### PR TITLE
Traduku "Sytherin" kiel "Sliteren" anstatux "Sliterin"

### DIFF
--- a/layout/hp-header.tex
+++ b/layout/hp-header.tex
@@ -26,7 +26,7 @@
 \input{layout/hp-markup}
 
 \hyphenation{Her-maj-ni Gran-ger Gri-fin-dor Le-stranĝ
-Hog-ŭartso Wi-zen-gam-ot Sli-te-rin Sli-te-rinoj Sli-te-rinojn
+Hog-ŭartso Wi-zen-gam-ot Sli-te-ren Sli-te-renoj Sli-te-renojn
 Se-ve-rus Mik-gon-agol Dum-bel-dor Kŭi-rel Mal-foj}
 
 


### PR DESCRIPTION
Poste iomete da tempo mi decidis ke 1) la "e" auxdigis pli bone al mi, kaj 2) "i" kauxzas la akuzativo igxi "Sliter*ino*n" por ambaux knaboj kaj knabinoj.